### PR TITLE
Allow execution of commands via method execute_command(<command name>)

### DIFF
--- a/FlyWithLua.cpp
+++ b/FlyWithLua.cpp
@@ -4849,6 +4849,22 @@ static int      LuaCreateCommand(lua_State *L)
     return 0;
 }
 
+static int      LuaExecuteCommand(lua_State *L)
+{
+    // usage: execute_command( "name" )
+    if (!(lua_isstring(L, 1) ))
+    {
+        logMsg(logToAll, "FlyWithLua Error: Wrong arguments to function execute_command().");
+        LuaIsRunning = false;
+        return 0;
+    }
+
+    XPLMCommandRef ref = XPLMFindCommand( lua_tostring(L, 1) );
+    XPLMCommandOnce(ref);
+
+    return 0;
+}
+
 static int      Luadirectory_to_table(lua_State *L)
 {
     char            DirectoryPath[LONGSTRING] = "";
@@ -5325,6 +5341,7 @@ void RegisterCoreCFunctionsToLua(lua_State *L)
     lua_register(L, "XPLMSetDatavf", LuaXPLMSetDatavf);
     lua_register(L, "XPLMGetDataRefTypes", LuaXPLMGetDataRefTypes);
     lua_register(L, "create_command", LuaCreateCommand);
+    lua_register(L, "execute_command", LuaExecuteCommand);
     lua_register(L, "directory_to_table", Luadirectory_to_table);
     lua_register(L, "peek", Luapeek);
     lua_register(L, "poke", Luapoke);


### PR DESCRIPTION
I use FlyWithLua to dynamically assign different functionality to keys, buttons and axes depending on the aircraft I fly. For this I've added a new method called execute_commands(). It allows me to not only assign datarefs to keys and buttons but also commands defined by Laminar or the aircraft author(s).

I propose to add this new method to the FlyWithLua product. Still it probably needs some refinements, especially with regard to error handling (given command was not found etc.).