### PR TITLE
Add check for undefined axis function

### DIFF
--- a/FlyWithLua/Internals/SaveInitialAssignments.ini
+++ b/FlyWithLua/Internals/SaveInitialAssignments.ini
@@ -64,7 +64,9 @@ function save_initial_assignments()
 		end
 		-- we do not need to kill axis twice, this was already done by clear_all_axis_assignments()
 		if axis_function_index > 0 then
-			textfile:write( "set_axis_assignment( " .. i .. ', "' .. axis_functions[axis_function_index] .. '", "' .. axis_reverse .. '" )\n' )
+			if axis_functions[axis_function_index] ~= nil then
+				textfile:write( "set_axis_assignment( " .. i .. ', "' .. axis_functions[axis_function_index] .. '", "' .. axis_reverse .. '" )\n' )
+			end
 		end
 	end
     


### PR DESCRIPTION
Something (suspect it was the JRollon CRJ200 or BSS sound pack) was causing FlyWithLua to stop.  One sim/joystick/joystick_axis_assignments element return as some large number (e.g. 16020).  This causes the axis_functions lookup to fail.

Added a check to prevent this error.