### PR TITLE
Fix datarefs with multiple types

### DIFF
--- a/src/FloatingWindows/FLWIntegration.cpp
+++ b/src/FloatingWindows/FLWIntegration.cpp
@@ -210,7 +210,7 @@ int LuaSetOnClickCallback(lua_State *L) {
     std::string cbName = lua_tostring(L, 2);
     wnd->setClickCallback([cbName] (FloatingWindow &fwnd, int x, int y, XPLMMouseStatus status) {
         if (!flywithlua::LuaIsRunning)  {
-            return true;
+            return;
         }
 
         lua_State *L = flywithlua::FWLLua;
@@ -218,7 +218,7 @@ int LuaSetOnClickCallback(lua_State *L) {
         lua_getglobal(L, cbName.c_str());
         if (!lua_isfunction(L, 1)) {
             lua_pop(L, 1);
-            return true;
+            return;
         }
 
         XPLMWindowID window = fwnd.getXWindow();
@@ -235,7 +235,7 @@ int LuaSetOnClickCallback(lua_State *L) {
         if (lua_pcall(L, 4, 0, 0)) {
             flywithlua::logMsg(logToAll, "FlyWithLua Error: Can't execute floating window click callback");
             flywithlua::LuaIsRunning = false;
-            return true;
+            return;
         }
         flywithlua::CopyDataRefsToXPlane();
     });


### PR DESCRIPTION
FlyWithLua has problems understanding datarefs that have multiple types because it uses the equal operator to check types instead of using the bitand operator.

Since this is in so many places of the code, I decided to add a compatibility layer instead of fixing all accesses. The layer suggests the correct type to use by converting multiple types to a sane single type, e.g. choosing double if the type is "int and float and double".