### PR TITLE
Added Travis CI configuration to test build on Linux, Windows and OS X.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: cpp
+compiler:
+  - gcc
+services:
+  - docker
+env:
+  - TARGET_PLATFORM=mac
+  - TARGET_PLATFORM=win
+  - TARGET_PLATFORM=lin
+before_install:
+  - chmod a+rwx src/
+  - (cd docker; make .image)
+script:
+  - (cd docker; make $TARGET_PLATFORM)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 FlyWithLua for X-Plane 11
 =========================
 
+[![Build Status](https://travis-ci.org/nevkontakte/FlyWithLua.svg)](https://travis-ci.org/nevkontakte/FlyWithLua)
+
 This is the official source code repository for the FlyWithLua plugin project.
 
 FlyWithLua offers Lua scripting to X-Plane since X-Plane 9.


### PR DESCRIPTION
This will allow to automatically build and test* FlyWithLua for every commit and pull request.

At the moment it doesn't do anything beyond just making sure FlyWithLua builds on all target platforms. In future it might do more interesting things like checking code formatting, running static code analysers and any other tools which might help us catching bugs.

You can see this in action for my fork: https://travis-ci.org/nevkontakte/FlyWithLua.

To enable TravisCI for the main repository we need to flip a switch for it at https://travis-ci.org/account/repositories (we might need @X-Friese to help us with this).

[*]: Once we have any kind of automated tests, that is.