### PR TITLE
Restore Lua 5.1 behavior for lua_tointeger() to mitigate #22.

### DIFF
--- a/src/third_party/sol2/README.md
+++ b/src/third_party/sol2/README.md
@@ -10,6 +10,13 @@ Directory `./upstream/` contains single-file version of Sol2 available from
  1. Download sol.hpp from [the master
     branch](https://github.com/ThePhD/sol2/blob/develop/single/sol/sol.hpp) on
     GitHub (or from Releases section) and place it under `./upstream`.
+ 2. Apply a patch for [issue
+    22](https://github.com/X-Friese/FlyWithLua/issues/22) if it hasn't been
+    resolved.
+    
+    ```bash
+    patch -p0 < fix_lua_tointeger.patch
+    ```
 
 Assuming there are no breaking changes, the new version should "just work".
 

--- a/src/third_party/sol2/fix_lua_tointeger.patch
+++ b/src/third_party/sol2/fix_lua_tointeger.patch
@@ -1,0 +1,20 @@
+Restore Lua 5.1 behavior for lua_tointeger() for non-sol2 code.
+
+Lua 5.3 introduced integer type along with a breaking change to lua_tointeger,
+which refuses to truncate floats to integers anymore. sol2 ships lua-compat-5.3
+library with it, which mimics the same behavior, which breaks current
+FlyWithLua users.
+
+See: https://github.com/X-Friese/FlyWithLua/issues/22
+--- ./upstream/sol.hpp
++++ ./upstream/sol.hpp
+@@ -22066,6 +22066,9 @@ namespace sol {
+ #endif 
+ #endif // Unreal Engine 4 Bullshit
+ 
++#undef lua_tointeger
++#undef lua_tointegerx
++
+ #endif // SOL_HPP
+ // end of sol.hpp
+ 

--- a/src/third_party/sol2/upstream/sol.hpp
+++ b/src/third_party/sol2/upstream/sol.hpp
@@ -22066,6 +22066,9 @@ namespace sol {
 #endif 
 #endif // Unreal Engine 4 Bullshit
 
+#undef lua_tointeger
+#undef lua_tointegerx
+
 #endif // SOL_HPP
 // end of sol.hpp
 


### PR DESCRIPTION
I'm not very proud of this fix because it involves patching a third-party library, but it should restore the original behavior for FlyWithLua code while we look for a nicer solution.