### PR TITLE
Add new XPLMFindCommand

### DIFF
--- a/FlyWithLua/Scripts (disabled)/WaitForCommandToBeCreated.lua
+++ b/FlyWithLua/Scripts (disabled)/WaitForCommandToBeCreated.lua
@@ -1,0 +1,77 @@
+-------------------------------
+--[[
+Example of use for XPLMFindCommand.
+  Some addons are creating custom commands/datarefs while they load.
+  This could cause issues if you use a FWL script that requires these inputs.
+  Since the FWL script also runs during load you may find that the command/dataref you want does not exist yet.
+  This is an example of how you could create a custom delay based on their creation.
+  In this example we get a message on the display as long as the command does not exist.
+
+If you wanted to use this to map joysticks dynamically:
+
+  You must load xplane once and go to the joystick setting once for these to be associated to Laminar's map.
+  For mapping you are interested in these arrays (found in the prf here: "<XP11Folder>\Output\preferences\X-Plane Joystick Settings.prf")
+
+  Axis: _joy_AXIS_use<i> <f>
+    where <i> = 0..499
+            Each joystick identified by xplane will have 25 axis reserved meaning that each joystick will be starting at a 25 axis offset.
+            In turn this means that XP11 has a limit of 20 usb input devices.
+          <f> = function to map to axis
+            It's a number so you'll have to go back and forth with XP11 to figure out what value = which axis.
+            For example, roll pitch yaw are 1,2 and 3 (not sure about the order however)
+            0 = not used.
+
+  Buttons: _joy_BUTN_use<i> <command>
+    where <i> = 0..3199
+            Each joystick identified by xplane will have 160 buttons reserved meaning that each joystick will be starting at a 160 button offset.
+            More on that is that the order of the button blocks will match the order of the joystick blocks.
+            This is usefull because if you've identified that the joystick you are trying to map with FWL is using axis 75-76-77 then you know it's buttons will start at 480.
+            Buttons are a little weirder than joysticks and sometimes it will skip. If your joystick has 10 buttons they may not be in the first 10 of the button block.
+            They only ceertainty is that they will be within the 160 block situated at 0 + 160x<joystick number>.
+          <command> = command name
+            This is a string so this makes it quite easy to find.
+            Set your button to something unique in XP11 then reload the prf file in your favorite text editor.
+            Found the line and copy the string into a set_button_assignment. (An example is provided below).
+--]]
+------------------------------
+
+function MapAircraftSpecific()
+  if (PLANE_ICAO == "A320") then
+  -- Flight Factor A320
+    -- set_button_assignment(<<BUTTON NUMBER>>, "a320/Panel/SidestickTakeoverL_button")
+    -- set_button_assignment(<<BUTTON NUMBER>>, "a320/Pedestal/EngineDisconnect1_button")
+  end
+end
+
+function specific_commands_exist()
+  local ac_ready = false
+  if PLANE_ICAO == "A320" then
+  -- Flight Factor A320
+    if XPLMFindCommand("a320/Panel/SidestickTakeoverL_button")   ~= nil and
+       XPLMFindCommand("a320/Pedestal/EngineDisconnect1_button") ~= nil then
+      ac_ready = true
+    end
+  else
+    ac_ready = true
+  end
+  return ac_ready
+end
+
+function monitor()
+  if not init_completed then
+    if specific_commands_exist() then
+      MapAircraftSpecific()
+      init_completed = true
+    else
+      draw_string_Helvetica_18(50, 500, "Waiting on A/C specific commands/datarefs to be created!")
+    end
+  end
+end
+
+local init_completed = false
+
+if init_completed == false then
+  do_every_draw("monitor()")
+else
+  do_sometimes("monitor()")
+end

--- a/docs/FlyWithLua_Manual_en.tex
+++ b/docs/FlyWithLua_Manual_en.tex
@@ -2336,6 +2336,15 @@ The same as above, but for float array DataRefs.
 
 The Lua variable will be filled with a >>userdata<<. This means, that you can't do anything with it's value. It's only needed for the XPLM functions.
 
+\subsubsection{\emph{userdata variable} = XPLMFindCommand( \emph{Command Name} )}
+
+\begin{enumerate}
+	\item \emph{userdata variable} = The lua variable, you want the reference to be pushed in.
+	\item \emph{Command name} = The name of the Command you want to know as a string.
+\end{enumerate}
+
+The Lua variable will be filled with a >>userdata<<. This means, that you can't do anything with it's value. One use case would be to wait until the specified command is not NIL before doing a set\_button\_assignment as some plugins may create commands during load time. This is an alternative to waiting for a fixed duration in the script for the Command to be created. 
+
 \subsubsection{\emph{datatype variable} = XPLMGetDataRefTypes( \emph{DataRef reference} )}
 
 \begin{enumerate}

--- a/src/FlyWithLua.cpp
+++ b/src/FlyWithLua.cpp
@@ -4848,6 +4848,25 @@ static int LuaXPLMFindDataRef(lua_State* L)
     return 1;
 }
 
+// The core access to Commands (for advanced users of FlyWithLua)
+static int LuaXPLMFindCommand(lua_State* L)
+{
+    char        CommandWanted[NORMALSTRING];
+    XPLMCommandRef CommandID;
+
+    strncpy(CommandWanted, luaL_checkstring(L, 1), sizeof(CommandWanted));
+
+    CommandID = XPLMFindCommand(CommandWanted);
+    if (CommandID != nullptr)
+    {
+        lua_pushlightuserdata(L, CommandID);
+    } else
+    {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
 static int LuaXPLMGetDatai(lua_State* L)
 {
     if (lua_islightuserdata(L, 1))
@@ -5878,6 +5897,7 @@ void RegisterCoreCFunctionsToLua(lua_State* L)
     lua_register(L, "begin_classic_mode", Luabegin_classic_mode);
     lua_register(L, "end_classic_mode", Luaend_classic_mode);
     lua_register(L, "XPLMFindDataRef", LuaXPLMFindDataRef);
+    lua_register(L, "XPLMFindCommand", LuaXPLMFindCommand);
     lua_register(L, "XPLMGetDatai", LuaXPLMGetDatai);
     lua_register(L, "XPLMGetDataf", LuaXPLMGetDataf);
     lua_register(L, "XPLMGetDatad", LuaXPLMGetDatad);

--- a/src/FlyWithLua.cpp
+++ b/src/FlyWithLua.cpp
@@ -2,7 +2,7 @@
 //  FlyWithLua Plugin for X-Plane 11
 // ----------------------------------
 
-#define PLUGIN_VERSION "2.7.20 build " __DATE__ " " __TIME__
+#define PLUGIN_VERSION "2.7.21 build " __DATE__ " " __TIME__
 
 #if CREATECOMPLETEEDITION
 
@@ -129,6 +129,7 @@
  *  v2.7.18 [changed] the size of Luadirectory_to_table to 1500 files or folders and 45000 characters.
  *  v2.7.19 [fixed]   issue with Arcaze not being found.
  *  v2.7.20 [changed] Remove the limit on the number of sounds.
+ *  v2.7.21 [added]   Support for XPLMFindCommand.
  *
  *
  *  Markus (Teddii):


### PR DESCRIPTION
Hello, first time doing a PR outside of my regular job.

Built locally (Ubuntu 18.04 lts VM) using the docker build. All three files have been generated.
Tested using X-Plane 11.40r1 on Windows 10.

Tex file updated using Tex Studio on Windows. Attempted to compile using TexLive on Windows but had a lot of compilation errors on lines that I had not modified. The modified section seemed to generate properly in the pdf file. I'll probably need the community to regenerate the pdf file for me.

I intend to release on the org forums an example of the script/modules I created that utilizes this new command. Since it requires modules for every joystick type me and my father use in our sims I have refrained to include it in the FWL default modules/examples since it's very specific and requires a complicated setup. I use it to dynamically rebind all joysticks when reloading a different aircraft. As opposed to the native XP11 profiles a FWL script allows us to layer the mapping. One example is that it unbinds the yoke and binds the sidestick when airbus and vice versa. Then for specific addons it binds the unique buttons commands. I'm using XPLMFindCommand to wait in my FWL script until the addon (FF A320 mostly) to finish creating it's custom commands and then map it. Without that you'd have to set a fixed value and hope that the commands are created by then without any way to validate their existence. 

Do not hesitate to leave comments if you require more information on my side.

Thank you,
Cedrik Lussier