### PR TITLE
Fix "reload-plugins" bug, and add missing dataref strings (as predefined PLANE_ globals).

### DIFF
--- a/src/FlyWithLua.cpp
+++ b/src/FlyWithLua.cpp
@@ -2,7 +2,7 @@
 //  FlyWithLua Plugin for X-Plane 11
 // ----------------------------------
 
-#define PLUGIN_VERSION "2.7.29 build " __DATE__ " " __TIME__
+#define PLUGIN_VERSION "2.7.30 build " __DATE__ " " __TIME__
 
 #define PLUGIN_NAME "FlyWithLua NG"
 #define PLUGIN_DESCRIPTION "Next Generation Version " PLUGIN_VERSION
@@ -968,6 +968,8 @@ XPLMDataRef gJoystickAxisReverse;
 XPLMDataRef gJoystickAxisValues;
 XPLMDataRef gPlaneICAO;
 XPLMDataRef gPlaneTailNumber;
+XPLMDataRef gPlaneDescrip;
+XPLMDataRef gPlaneAuthor;
 
 
 // We interact with XSquawkBox
@@ -6631,6 +6633,8 @@ bool ReadAllScriptFiles()
     char FileToLoad[SHORTSRTING]      = "";
     char PlaneICAO[SHORTSRTING]       = "";
     char PlaneTailNumber[SHORTSRTING] = "";
+    char PlaneDescrip[SHORTSRTING]    = "";
+    char PlaneAuthor[SHORTSRTING]     = "";
     int  k;
     char FilesInFolder[5000];
     int NumberOfFiles; // modified by saar
@@ -6669,6 +6673,12 @@ bool ReadAllScriptFiles()
     XPLMGetDatab(gPlaneTailNumber, PlaneTailNumber, 0, SHORTSRTING);
     lua_pushstring(FWLLua, PlaneTailNumber);
     lua_setglobal(FWLLua, "PLANE_TAILNUMBER");
+    XPLMGetDatab(gPlaneDescrip, PlaneDescrip, 0, SHORTSRTING);
+    lua_pushstring(FWLLua, PlaneDescrip);
+    lua_setglobal(FWLLua, "PLANE_DESCRIP");
+    XPLMGetDatab(gPlaneAuthor, PlaneAuthor, 0, SHORTSRTING);
+    lua_pushstring(FWLLua, PlaneAuthor);
+    lua_setglobal(FWLLua, "PLANE_AUTHOR");
 
     // if we are still in boot phase of X-Plane, we do not want to load files
     if (XPLMInitialized() == 0)
@@ -7062,6 +7072,8 @@ PLUGIN_API int XPluginStart(
     gJoystickButtonValues      = XPLMFindDataRef("sim/joystick/joystick_button_values");
     gPlaneICAO                 = XPLMFindDataRef("sim/aircraft/view/acf_ICAO");
     gPlaneTailNumber           = XPLMFindDataRef("sim/aircraft/view/acf_tailnum");
+    gPlaneDescrip              = XPLMFindDataRef("sim/aircraft/view/acf_descrip");
+    gPlaneAuthor               = XPLMFindDataRef("sim/aircraft/view/acf_author");
 
     // Lua run numbering starts at zero (no runs) when X-Plane starts
     LuaResetCount = 0;
@@ -7298,7 +7310,7 @@ PLUGIN_API int XPluginEnable(void)
     luaL_openlibs(FWLLua);
 
     // reload all script files, if the plugin is re-enabled via X-Plane's plugin manager menu
-    if (LuaResetCount > 0)
+    if (LuaResetCount > 0 || XPLMGetCycleNumber() > 0)
     {
         ReadAllScriptFiles();
     }


### PR DESCRIPTION
This PR has two changes (three if you include the version number change). The changes are readily separable if required:

0. Bump the build number to 2.7.30 (to make it easier for you to integrate if you like it as-is).

1. Fix "reload plugins" to correctly reload FWL scripts after start. (One-line change; see line #7313 herein.)
    - For years, every time the user does a "reload plugins" (e.g. using the command in DRT), FWL gets into a strange state, displaying an error after reload, saying `FLYWITHLUA_DEBUG()` is **not defined**. (The Lua engine is, at that point, stopped unless the user manually invokes the "reload scripts" command.)
    - To fix this, we simply make sure `ReadAllScriptFiles()` is called not only when *`LuaResetCount > 0`* (as it is now), but also when ***`XPLMGetCycleNumber() > 0`*** (meaning the simulator has already started up).  This allows us to correctly detect that `XPluginEnable()` was invoked after a reload-plugins event! (I have used this successfully in other projects as a quick way to detect this case.)
    - Alternatively, to be conservative, you could change this to *`XPLMGetCycleNumber() > 9999`* (or some other constant number of cycles after start), so it doesn't otherwise trigger too early; but I don't think this is necessary.

2. Add two missing predefined global string datarefs from User aircraft file (provided by XPLM): **`PLANE_AUTHOR`** and **`PLANE_DESCRIP`**.
    - This is more code than the first change above, but it is very straightforward.
    - We simply define new plugin globals *`gPlaneDescrip`* and *`gPlaneAuthor`*, and look up the datarefs in `XPluginStart()`.
    - We define new string globals *`PlaneDescrip[]`* and *`PlaneAuthor[]`* to hold the strings, of size (sic) `SHORTSRTING` chars.
    - We fetch the dataref byte-array data just as is already done with `PLANE_TAILNUMBER` and `PLANE_ICAO` globals.
    - We export both as globals within the user's FWL context, i.e., `PLANE_DESCRIP` and `PLANE_AUTHOR`.

Both of these changes were tested out, and FWL starts up just fine on Mac, Linux, and Windows, and the new variables are available and correctly mirror the User aircraft's state as well.

I even verified that the new globals are correctly updated after changing User aircraft (i.e., by loading a new aircraft, and running the test script again).  Note that the globals added update each time the aircraft is changed because FlyWithLua reloads all scripts at that point, which runs the same dataref code (as with `PLANE_ICAO` and `PLANE_TAILNUMBER`.

(There is no good way to automatically test the first change. It's just a matter of verifying that FlyWithLua actually doesn't fail to come up after a reload-plugins event!)