### PR TITLE
Adds sleep(millis) function 

### DIFF
--- a/FlyWithLua/Scripts (disabled)/fps_limit.lua
+++ b/FlyWithLua/Scripts (disabled)/fps_limit.lua
@@ -1,0 +1,37 @@
+dataref("FRAMERATE_PERIOD", "sim/time/framerate_period", "readonly")
+
+TARGET_FPS = 25.0
+FPS = 0
+SLEEP_MILLIS = 0
+ENABLED = 0
+
+add_macro("FPS Limit", "ENABLED = 1", "ENABLED = 0", "deactivate")
+
+do_every_frame("every_frame()")
+
+function every_frame()
+    if ENABLED == 1 then
+        calc_limit()
+        limit()
+    end
+end
+
+function limit()
+    if SLEEP_MILLIS > 0 then
+        sleep(SLEEP_MILLIS)
+    end
+end
+
+function calc_limit()
+    FPS = 1.0 / FRAMERATE_PERIOD
+
+    if TARGET_FPS < FPS then
+        SLEEP_MILLIS = SLEEP_MILLIS + 1000
+    elseif TARGET_FPS > FPS then
+        SLEEP_MILLIS = SLEEP_MILLIS - 1000
+    end
+
+    if SLEEP_MILLIS < 0 then
+        SLEEP_MILLIS = 0
+    end
+end

--- a/src/FlyWithLua.cpp
+++ b/src/FlyWithLua.cpp
@@ -4241,6 +4241,13 @@ static int LuaCreateNegativeEdgeDecrement(lua_State* L)
     return 0;
 }
 
+// millis
+static int LuaSleep(lua_State *L)
+{
+    int m = static_cast<int> (luaL_checknumber(L,1));
+    usleep(m*1000);
+    return 0;
+}
 
 static int LuaSetPilotsHead(lua_State* L)
 {
@@ -5920,6 +5927,7 @@ void RegisterCoreCFunctionsToLua(lua_State* L)
     lua_register(L, "directory_to_table", Luadirectory_to_table);
     lua_register(L, "peek", Luapeek);
     lua_register(L, "poke", Luapoke);
+    lua_register(L, "sleep", LuaSleep);
     lua_register(L, "set_pilots_head", LuaSetPilotsHead);
     lua_register(L, "get_pilots_head", LuaGetPilotsHead);
     lua_register(L, "place_aircraft_at", LuaPlaceUserAtAirport);


### PR DESCRIPTION
Hi Carsten, First of all thank you for the wonderful FylWithLua!

I've added a sleep function using usleep(nanos). I needed it for my Lua script "fps_limit.lua", that limits the FPS to 25 in order to save energy and save me from loud fan noise. I did not add it to the documentation yet because I'm not even sure what you think about it. I just thought you may like the idea. I have also implemented my FPS limit function as a plugin written in C, but I loved how I could prototype it with FlyWithLua. Obviously it's a kind of dangerous function, because it suspends threads... so feel free to ignore my pull request.