### PR TITLE
Debug output for sound elements is written directly to the debug file

### DIFF
--- a/src/FlyWithLua.cpp
+++ b/src/FlyWithLua.cpp
@@ -6213,26 +6213,19 @@ void DebugLua()
     DebugFile << "\n\n*** OpenAL sound files are stored in a table ***\n";
     if (!OpenALSounds.empty())
     {
-        std::ostringstream oss_WhatToSay;
-        std::string WhatToSay;
         for (const OpenALSoundsStructure & sound : OpenALSounds)
         {
             DebugFile << "<<< Sound table element >>>\n";
             DebugFile << "filename --> \"" << sound.filename << "\"\n";
             if (sound.loop)
             {
-                oss_WhatToSay << "pitch    --> " << sound.pitch << "\ngain     --> " << sound.gain <<
+                DebugFile << "pitch    --> " << sound.pitch << "\ngain     --> " << sound.gain <<
                                  "\nloop     --> true\nsource   --> " << sound.source << "\n\n";
-
-                WhatToSay = oss_WhatToSay.str();
             } else
             {
-                oss_WhatToSay << "pitch    --> " << sound.pitch << "\ngain     --> " << sound.gain <<
+                DebugFile << "pitch    --> " << sound.pitch << "\ngain     --> " << sound.gain <<
                                  "\nloop     --> false\nsource   --> " << sound.source << "\n\n";
-
-                WhatToSay = oss_WhatToSay.str();
             }
-            DebugFile << WhatToSay.c_str();
         }
     } else
     {
@@ -7507,7 +7500,7 @@ float MyFastLoopCallback(
         UserWantsToMoveAircraft    = false;
         LuaIsRunning               = false;
         XPLMPlaceUserAtLocation(
-            UserWantedPosHdgSpd[0], 
+            UserWantedPosHdgSpd[0],
             UserWantedPosHdgSpd[1],
             UserWantedPosHdgSpd[2],
             UserWantedPosHdgSpd[3],


### PR DESCRIPTION
When writing the debug output, the debug data for each element in the sound table was written multiple times, because the debug data of each element was attached to the previously written data. The debug data is now written directly to the debug file instead of using temporary variables.

My checklist extensions loads over 100 sounds, which made it very difficult to get the correct information. Here is a comparison of the debug data before and after my change:

[SoundTableDebugContent_BeforeChange.txt](https://github.com/X-Friese/FlyWithLua/files/8051428/SoundTableDebugContent_BeforeChange.txt)
[SoundTableDebugContent_AfterChange.txt](https://github.com/X-Friese/FlyWithLua/files/8051427/SoundTableDebugContent_AfterChange.txt)