### PR TITLE
Fix cowl flap axis assignment

### DIFF
--- a/src/FlyWithLua.cpp
+++ b/src/FlyWithLua.cpp
@@ -3103,7 +3103,7 @@ static int LuaSetAxisAssignment(lua_State* L)
         CommandRefIdWanted = 0;
 
     // instead we have a new function
-    else if (CommandWanted == "Cowl flaps")
+    else if (CommandWanted == "cowl flaps")
         CommandRefIdWanted = 39;
 
     // and nothing for the index value 40


### PR DESCRIPTION
Capitalization of Cowl flaps prevents assigning it as an axis.